### PR TITLE
Fixed some MSVC W4 compiler warnings

### DIFF
--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -2951,11 +2951,10 @@ bool BlockMetadata_Generic::CheckAllocation(
     // Start from offset equal to beginning of this suballocation.
     *pOffset = suballoc.offset;
 
+    #if (D3D12MA_DEBUG_MARGIN > 0)
     // Apply D3D12MA_DEBUG_MARGIN at the beginning.
-    if(D3D12MA_DEBUG_MARGIN > 0)
-    {
-        *pOffset += D3D12MA_DEBUG_MARGIN;
-    }
+    *pOffset += D3D12MA_DEBUG_MARGIN;
+    #endif // D3D12MA_DEBUG_MARGIN
 
     // Apply alignment.
     *pOffset = AlignUp(*pOffset, allocAlignment);

--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -4769,7 +4769,7 @@ void AllocatorPimpl::CalculateStats(Stats& outStats)
     // Process custom pools
     for(size_t heapTypeIndex = 0; heapTypeIndex < HEAP_TYPE_COUNT; ++heapTypeIndex)
     {
-        StatInfo& heapStatInfo = outStats.HeapType[heapTypeIndex];
+        //StatInfo& heapStatInfo = outStats.HeapType[heapTypeIndex];
         MutexLockRead lock(m_PoolsMutex[heapTypeIndex], m_UseMutex);
         const PoolVectorType* const poolVector = m_pPools[heapTypeIndex];
         D3D12MA_ASSERT(poolVector);

--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -2710,8 +2710,8 @@ bool BlockMetadata_Generic::Validate() const
 
             #if (D3D12MA_DEBUG_MARGIN != 0)
             // Margin required between allocations - previous allocation must be free.
-			D3D12MA_VALIDATE(prevFree);
-			#endif // D3D12MA_DEBUG_MARGIN
+            D3D12MA_VALIDATE(prevFree);
+            #endif // D3D12MA_DEBUG_MARGIN
         }
 
         calculatedOffset += subAlloc.size;

--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -2708,8 +2708,10 @@ bool BlockMetadata_Generic::Validate() const
             D3D12MA_VALIDATE(subAlloc.allocation->GetOffset() == subAlloc.offset);
             D3D12MA_VALIDATE(subAlloc.allocation->GetSize() == subAlloc.size);
 
+            #if (D3D12MA_DEBUG_MARGIN != 0)
             // Margin required between allocations - previous allocation must be free.
-            D3D12MA_VALIDATE(D3D12MA_DEBUG_MARGIN == 0 || prevFree);
+			D3D12MA_VALIDATE(prevFree);
+			#endif // D3D12MA_DEBUG_MARGIN
         }
 
         calculatedOffset += subAlloc.size;

--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -1212,9 +1212,9 @@ void JsonWriter::ContinueString(LPCWSTR pStr)
                     UINT hexDigit = (val & 0xF000) >> 12;
                     val <<= 4;
                     if (hexDigit < 10)
-                        m_SB.Add(L'0' + hexDigit);
+                        m_SB.Add(L'0' + (WCHAR)hexDigit);
                     else
-                        m_SB.Add(L'A' + hexDigit);
+                        m_SB.Add(L'A' + (WCHAR)hexDigit);
                 }
             }
             break;

--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -3643,6 +3643,8 @@ HRESULT BlockVector::AllocateFromBlock(
     ALLOCATION_FLAGS allocFlags,
     Allocation** pAllocation)
 {
+    (void)allocFlags; // unused variable
+    
     AllocationRequest currRequest = {};
     if(pBlock->m_pMetadata->CreateAllocationRequest(
         size,
@@ -4416,6 +4418,8 @@ HRESULT AllocatorPimpl::SetDefaultHeapMinBytes(
 
 bool AllocatorPimpl::PrefersCommittedAllocation(const D3D12_RESOURCE_DESC& resourceDesc)
 {
+    (void)resourceDesc; // unused variable
+    
     // Intentional. It may change in the future.
     return false;
 }
@@ -5279,6 +5283,8 @@ void Allocation::InitCommitted(D3D12_HEAP_TYPE heapType)
 
 void Allocation::InitPlaced(UINT64 offset, UINT64 alignment, NormalBlock* block)
 {
+    (void)alignment; // unused variable
+    
     m_PackedData.SetType(TYPE_PLACED);
     m_Placed.offset = offset;
     m_Placed.block = block;

--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -134,7 +134,7 @@ static T* AllocateArray(const ALLOCATION_CALLBACKS& allocs, size_t count)
 #define D3D12MA_NEW_ARRAY(allocs, type, count) new(D3D12MA::AllocateArray<type>((allocs), (count)))(type)
 
 template<typename T>
-static void D3D12MA_DELETE(const ALLOCATION_CALLBACKS& allocs, T* memory)
+void D3D12MA_DELETE(const ALLOCATION_CALLBACKS& allocs, T* memory)
 {
     if(memory)
     {


### PR DESCRIPTION
There is still one type of warnings left:
- Added padding (requires pragmas/compiler flags to suppress).