### PR TITLE
Do not define empty non-virtual destructors

### DIFF
--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -1553,7 +1553,6 @@ public:
 
     // allocationCallbacks externally owned, must outlive this object.
     List(const ALLOCATION_CALLBACKS& allocationCallbacks);
-    ~List();
     void Clear();
 
     size_t GetCount() const { return m_Count; }
@@ -1774,13 +1773,6 @@ List<T>::List(const ALLOCATION_CALLBACKS& allocationCallbacks) :
     m_pBack(NULL),
     m_Count(0)
 {
-}
-
-template<typename T>
-List<T>::~List()
-{
-    // Intentionally not calling Clear, because that would be unnecessary
-    // computations to return all items to m_ItemAllocator as free.
 }
 
 template<typename T>
@@ -6002,11 +5994,6 @@ Allocation::Allocation(AllocatorPimpl* allocator, UINT64 size, BOOL wasZeroIniti
     m_PackedData.SetWasZeroInitialized(wasZeroInitialized);
 }
 
-Allocation::~Allocation()
-{
-    // Nothing here, everything already done in Release.
-}
-
 void Allocation::InitCommitted(CommittedAllocationList* list)
 {
     m_PackedData.SetType(TYPE_COMMITTED);
@@ -6311,7 +6298,6 @@ public:
     BlockMetadata_Generic m_Metadata;
 
     VirtualBlockPimpl(const ALLOCATION_CALLBACKS& allocationCallbacks, UINT64 size);
-    ~VirtualBlockPimpl();
 };
 
 VirtualBlockPimpl::VirtualBlockPimpl(const ALLOCATION_CALLBACKS& allocationCallbacks, UINT64 size) :
@@ -6321,10 +6307,6 @@ VirtualBlockPimpl::VirtualBlockPimpl(const ALLOCATION_CALLBACKS& allocationCallb
         true) // isVirtual
 {
     m_Metadata.Init(m_Size);
-}
-
-VirtualBlockPimpl::~VirtualBlockPimpl()
-{
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -1553,6 +1553,11 @@ public:
 
     // allocationCallbacks externally owned, must outlive this object.
     List(const ALLOCATION_CALLBACKS& allocationCallbacks);
+
+    // Intentionally not calling Clear, because that would be unnecessary
+    // computations to return all items to m_ItemAllocator as free.
+    // ~List() {}
+    
     void Clear();
 
     size_t GetCount() const { return m_Count; }

--- a/src/D3D12MemAlloc.h
+++ b/src/D3D12MemAlloc.h
@@ -401,6 +401,9 @@ private:
     } m_PackedData;
 
     Allocation(AllocatorPimpl* allocator, UINT64 size, BOOL wasZeroInitialized);
+    //  Nothing here, everything already done in Release.
+    // ~Allocation() {}
+    
     void InitCommitted(CommittedAllocationList* list);
     void InitPlaced(UINT64 offset, UINT64 alignment, NormalBlock* block);
     void InitHeap(CommittedAllocationList* list, ID3D12Heap* heap);

--- a/src/D3D12MemAlloc.h
+++ b/src/D3D12MemAlloc.h
@@ -401,7 +401,6 @@ private:
     } m_PackedData;
 
     Allocation(AllocatorPimpl* allocator, UINT64 size, BOOL wasZeroInitialized);
-    ~Allocation();
     void InitCommitted(CommittedAllocationList* list);
     void InitPlaced(UINT64 offset, UINT64 alignment, NormalBlock* block);
     void InitHeap(CommittedAllocationList* list, ID3D12Heap* heap);


### PR DESCRIPTION
Providing an empty definition of a non-virtual destructor is pointless, as the compiler can implicitly provide the definition itself. Moreover, it makes a type non-trivially destructible what prevents the compiler from applying certain optimizations (this isn't the case in this PR).