### PR TITLE
Add option to build as shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 find_package(Doxygen)
 option(BUILD_DOCUMENTATION "Create and install the HTML-based API documentation (requires Doxygen)" OFF)
+option(BUILD_SHARED_LIBS "Build D3D12 Memory Allocator shared library" OFF)
 
 if (DOXYGEN_FOUND AND BUILD_DOCUMENTATION)
     # set input and output files
@@ -29,4 +30,5 @@ option(D3D12MA_BUILD_SAMPLE "Build D3D12MemoryAllocator sample application" OFF)
 
 message(STATUS "D3D12MA_BUILD_SAMPLE = ${D3D12MA_BUILD_SAMPLE}")
 
+include_directories(include)
 add_subdirectory(src)

--- a/include/D3D12MemAlloc.h
+++ b/include/D3D12MemAlloc.h
@@ -118,9 +118,17 @@ If providing your own implementation, you need to implement a subset of std::ato
     #define D3D12MA_ATOMIC_UINT64 std::atomic<UINT64>
 #endif
 
+#ifdef D3D12MA_EXPORTS
+    #define D3D12MA_API __declspec(dllexport)
+#elif defined(D3D12MA_IMPORTS)
+    #define D3D12MA_API __declspec(dllimport)
+#else
+    #define D3D12MA_API
+#endif
+
 namespace D3D12MA
 {
-class IUnknownImpl : public IUnknown
+class D3D12MA_API IUnknownImpl : public IUnknown
 {
 public:
     virtual ~IUnknownImpl() = default;
@@ -253,7 +261,7 @@ To retrieve this information, use methods of this class.
 The object also remembers `ID3D12Resource` and "owns" a reference to it,
 so it calls `%Release()` on the resource when destroyed.
 */
-class Allocation : public IUnknownImpl
+class D3D12MA_API Allocation : public IUnknownImpl
 {
 public:
     /** \brief Returns offset in bytes from the start of memory heap.
@@ -470,7 +478,7 @@ pools - creating resources in default pool is sufficient.
 
 To create custom pool, fill D3D12MA::POOL_DESC and call D3D12MA::Allocator::CreatePool.
 */
-class Pool : public IUnknownImpl
+class D3D12MA_API Pool : public IUnknownImpl
 {
 public:
     /** \brief Returns copy of parameters of the pool.
@@ -658,7 +666,7 @@ Call method `Release()` to destroy it.
 It is recommended to create just one object of this type per `ID3D12Device` object,
 right after Direct3D 12 is initialized and keep it alive until before Direct3D device is destroyed.
 */
-class Allocator : public IUnknownImpl
+class D3D12MA_API Allocator : public IUnknownImpl
 {
 public:
     /// Returns cached options retrieved from D3D12 device.
@@ -866,7 +874,7 @@ protected:
     virtual void ReleaseThis();
 
 private:
-    friend HRESULT CreateAllocator(const ALLOCATOR_DESC*, Allocator**);
+    friend D3D12MA_API HRESULT CreateAllocator(const ALLOCATOR_DESC*, Allocator**);
     template<typename T> friend void D3D12MA_DELETE(const ALLOCATION_CALLBACKS&, T*);
     friend class Pool;
 
@@ -938,7 +946,7 @@ To create this object, fill in D3D12MA::VIRTUAL_BLOCK_DESC and call CreateVirtua
 To destroy it, call its method `VirtualBlock::Release()`.
 You need to free all the allocations within this block or call Clear() before destroying it.
 */
-class VirtualBlock : public IUnknownImpl
+class D3D12MA_API VirtualBlock : public IUnknownImpl
 {
 public:
     /** \brief Returns true if the block is empty - contains 0 allocations.
@@ -981,7 +989,7 @@ protected:
     virtual void ReleaseThis();
 
 private:
-    friend HRESULT CreateVirtualBlock(const VIRTUAL_BLOCK_DESC*, VirtualBlock**);
+    friend D3D12MA_API HRESULT CreateVirtualBlock(const VIRTUAL_BLOCK_DESC*, VirtualBlock**);
     template<typename T> friend void D3D12MA_DELETE(const ALLOCATION_CALLBACKS&, T*);
 
     VirtualBlockPimpl* m_Pimpl;
@@ -996,13 +1004,13 @@ private:
 
 You normally only need to call it once and keep a single Allocator object for your `ID3D12Device`.
 */
-HRESULT CreateAllocator(const ALLOCATOR_DESC* pDesc, Allocator** ppAllocator);
+D3D12MA_API HRESULT CreateAllocator(const ALLOCATOR_DESC* pDesc, Allocator** ppAllocator);
 
 /** \brief Creates new D3D12MA::VirtualBlock object and returns it through `ppVirtualBlock`.
 
 Note you don't need to create D3D12MA::Allocator to use virtual blocks.
 */
-HRESULT CreateVirtualBlock(const VIRTUAL_BLOCK_DESC* pDesc, VirtualBlock** ppVirtualBlock);
+D3D12MA_API HRESULT CreateVirtualBlock(const VIRTUAL_BLOCK_DESC* pDesc, VirtualBlock** ppVirtualBlock);
 
 } // namespace D3D12MA
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(D3D12MA_LIBRARY_SOURCE_FILES
-    D3D12MemAlloc.h
+    ../include/D3D12MemAlloc.h
     D3D12MemAlloc.cpp
 )
 set(CMAKE_DEBUG_POSTFIX d)
@@ -15,6 +15,8 @@ set_target_properties(
     # Use C++14
     CXX_STANDARD 14
     CXX_STANDARD_REQUIRED ON
+
+    OUTPUT_NAME "d3d12ma"
 )
 
 target_link_libraries(D3D12MemoryAllocator PUBLIC
@@ -22,6 +24,16 @@ target_link_libraries(D3D12MemoryAllocator PUBLIC
     dxgi.lib
     dxguid.lib
 )
+
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(D3D12MemoryAllocator PRIVATE
+        D3D12MA_EXPORTS
+    )
+
+    target_compile_definitions(D3D12MemoryAllocator INTERFACE
+        D3D12MA_IMPORTS
+    )
+endif()
 
 install(TARGETS D3D12MemoryAllocator DESTINATION lib)
 install(FILES D3D12MemAlloc.h DESTINATION include)


### PR DESCRIPTION
I'm strongly against mixing dynamic and static linking in my dynamically linked project, so I took the time to implement imports/exports API macro. I have also moved public header to a publicly available separate directory.

This is a replacement of #25 after I had to rebase the repository.
Something got messed up when I moved the file and Git wouldn't want to pick it up properly with `git add .`.
In the end I had to copy backed up files over to a clean repository and then `git mv ./src/D3D12MemAlloc.h ./include/D3D12MemAlloc.h` to make it work.