### PR TITLE
Fix export of custom pool names

### DIFF
--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -7449,8 +7449,8 @@ void AllocatorPimpl::BuildStatsString(WCHAR** ppStatsString, BOOL detailedMap)
                         json.ContinueString(index++);
                         if (item->GetName())
                         {
-                            json.WriteString(L" - ");
-                            json.WriteString(item->GetName());
+                            json.ContinueString(L" - ");
+                            json.ContinueString(item->GetName());
                         }
                         json.EndString();
 


### PR DESCRIPTION
If a custom pool has a name, the WriteString will create a crash because it is inside a BeginString / EndString bloc.