### PR TITLE
Use list initialization for atomics

### DIFF
--- a/include/D3D12MemAlloc.h
+++ b/include/D3D12MemAlloc.h
@@ -145,7 +145,7 @@ public:
 protected:
     virtual void ReleaseThis() { delete this; }
 private:
-    D3D12MA_ATOMIC_UINT32 m_RefCount = 1;
+    D3D12MA_ATOMIC_UINT32 m_RefCount = {1};
 };
 } // namespace D3D12MA
 

--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -6120,7 +6120,7 @@ private:
     D3D12MA_ATOMIC_UINT64 m_BlockBytes[DXGI_MEMORY_SEGMENT_GROUP_COUNT] = {};
     D3D12MA_ATOMIC_UINT64 m_AllocationBytes[DXGI_MEMORY_SEGMENT_GROUP_COUNT] = {};
 
-    D3D12MA_ATOMIC_UINT32 m_OperationsSinceBudgetFetch = 0;
+    D3D12MA_ATOMIC_UINT32 m_OperationsSinceBudgetFetch = {0};
     D3D12MA_RW_MUTEX m_BudgetMutex;
     UINT64 m_D3D12Usage[DXGI_MEMORY_SEGMENT_GROUP_COUNT] = {};
     UINT64 m_D3D12Budget[DXGI_MEMORY_SEGMENT_GROUP_COUNT] = {};
@@ -6355,7 +6355,7 @@ class AllocatorPimpl
     friend class Allocator;
     friend class Pool;
 public:
-    std::atomic_uint32_t m_RefCount = 1;
+    std::atomic_uint32_t m_RefCount = {1};
     CurrentBudgetData m_Budget;
 
     AllocatorPimpl(const ALLOCATION_CALLBACKS& allocationCallbacks, const ALLOCATOR_DESC& desc);


### PR DESCRIPTION
Hi, I encountered this issue when integrating with my project, so here's my small contribution to be reviewed.

Project does not compile using Clang 11.0.0 with Visual Studio Build Tools 16.0.

Compiler complains about atomics initializations, which apparently are matched to `std::atomic` copy constructor that is marked as deleted
```cpp
    atomic(const atomic&) = delete;
    atomic& operator=(const atomic&) = delete;
```
The simple fix is to use curly braces init, in similar fashion as in other places in the codebase