### PR TITLE
Support using open-sourced DirectX headers.

### DIFF
--- a/include/D3D12MemAlloc.h
+++ b/include/D3D12MemAlloc.h
@@ -61,7 +61,13 @@ Documentation of all members: D3D12MemAlloc.h
 // If using this library on a platform different than Windows PC or want to use different version of DXGI,
 // you should include D3D12-compatible headers before this library on your own and define this macro.
 #ifndef D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED
-    #include <d3d12.h>
+    #if defined(USING_DIRECTX_HEADERS)
+        #include <directx/d3d12.h>
+        #include <dxguids/dxguids.h>
+    #else
+        #include <d3d12.h>
+    #endif
+    
     #include <dxgi1_4.h>
 #endif
 

--- a/include/D3D12MemAlloc.h
+++ b/include/D3D12MemAlloc.h
@@ -59,9 +59,12 @@ Documentation of all members: D3D12MemAlloc.h
 */
 
 // If using this library on a platform different than Windows PC or want to use different version of DXGI,
-// you should include D3D12-compatible headers before this library on your own and define this macro.
+// you should include D3D12-compatible headers before this library on your own and define 
+// D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED.
+// Alternatively, if you are targeting the open sourced DirectX headers, defining D3D12MA_USING_DIRECTX_HEADERS
+// will include them rather the ones provided by the Windows SDK.
 #ifndef D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED
-    #if defined(USING_DIRECTX_HEADERS)
+    #if defined(D3D12MA_USING_DIRECTX_HEADERS)
         #include <directx/d3d12.h>
         #include <dxguids/dxguids.h>
     #else


### PR DESCRIPTION
When using the headers from the open-sourced [DirectX headers](https://github.com/microsoft/DirectX-Headers) repository, the includes need to be slightly different in order for them to be picked up properly. I've added a the check for `USING_DIRECTX_HEADERS` to enable this.

I am the author of the vcpkg port and want to update it with the next release, since the port currently uses an outdated version. PR #44 introduced support for the new resource allocation API. However, this API can only be used with the [Agility SDK](https://devblogs.microsoft.com/directx/directx12agility/) on some Windows versions. This also means that one has to use the open-sourced D3D headers, since they are more up-to-date than what might be available in the Windows SDK. The vcpkg port pre-builds the project as a static library, which with the current implementation always has to `#include <d3d12.h>`. It is not possible to direct it somewhere else and using `D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED` is not helpful in this case. For the next version, I could instead let the port depend on the open sourced headers and set `USING_DIRECTX_HEADERS`.

If you do not want to include this PR, it would still be possible to resolve this through manual patches, but I think builtin support for the DX headers project is also nice to have. 🙂