### PR TITLE
fix potential compile errors if strict mode (/permissive-) is enabled

### DIFF
--- a/src/D3D12Sample.cpp
+++ b/src/D3D12Sample.cpp
@@ -1801,13 +1801,14 @@ int Main2(int argc, wchar_t** argv)
         return (int)ExitCode::Help;
     }
 
-    std::unique_ptr<DXGIUsage> DXGIUsage(new DXGIUsage());
-    DXGIUsage->Init();
-    g_DXGIUsage = DXGIUsage.get();
+    // variable name should not same as class name
+    std::unique_ptr<DXGIUsage> dxgiUsage = std::make_unique<DXGIUsage>();
+    dxgiUsage->Init();
+    g_DXGIUsage = dxgiUsage.get();
 
     if(g_CommandLineParameters.m_List)
     {
-        DXGIUsage->PrintAdapterList();
+        dxgiUsage->PrintAdapterList();
         return (int)ExitCode::GPUList;
     }
 


### PR DESCRIPTION
Note that by default MSVC does not enable strict mode for C++14/17, but it is enabled by default starting from C++20.
https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-170
```
[build] C:\Users\Admin\Desktop\D3D12MemoryAllocator\src\D3D12Sample.cpp(1804,46): error C2061: syntax error: identifier 'DXGIUsage' 
```