### PR TITLE
Fix GetResourceAllocationInfo2 and GetResourceAllocationInfo calls to work on non-msvc compilers with DirectX-Headers

### DIFF
--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -8187,7 +8187,12 @@ HRESULT AllocatorPimpl::UpdateD3D12Budget()
 
 D3D12_RESOURCE_ALLOCATION_INFO AllocatorPimpl::GetResourceAllocationInfoNative(const D3D12_RESOURCE_DESC& resourceDesc) const
 {
+#if defined(_MSC_VER) || !defined(_WIN32)
     return m_Device->GetResourceAllocationInfo(0, 1, &resourceDesc);
+#else
+    D3D12_RESOURCE_ALLOCATION_INFO RetVal;
+    return *m_Device->GetResourceAllocationInfo(&RetVal, 0, 1, &resourceDesc);
+#endif
 }
 
 #ifdef __ID3D12Device8_INTERFACE_DEFINED__
@@ -8195,7 +8200,12 @@ D3D12_RESOURCE_ALLOCATION_INFO AllocatorPimpl::GetResourceAllocationInfoNative(c
 {
     D3D12MA_ASSERT(m_Device8 != NULL);
     D3D12_RESOURCE_ALLOCATION_INFO1 info1Unused;
+#if defined(_MSC_VER) || !defined(_WIN32)
     return m_Device8->GetResourceAllocationInfo2(0, 1, &resourceDesc, &info1Unused);
+#else
+    D3D12_RESOURCE_ALLOCATION_INFO RetVal;
+    return *m_Device8->GetResourceAllocationInfo2(&RetVal, 0, 1, &resourceDesc, &info1Unused);
+#endif
 }
 #endif // #ifdef __ID3D12Device8_INTERFACE_DEFINED__
 


### PR DESCRIPTION
Hi!

I'm maintaining my own set of Rust bindings to this library. I'm trying to maintain GCC/Clang support for the `gnu` Rust toolchain for my bindings but I've run into a snag with how this library calls the `GetResourceAllocationInfo` family of functions.

I'm using the https://github.com/microsoft/DirectX-Headers d3d12 headers as the mingw d3d12 headers are very outdated. `GetResourceAllocationInfo` and friends are defined like this:

```cpp
#if defined(_MSC_VER) || !defined(_WIN32)
        virtual D3D12_RESOURCE_ALLOCATION_INFO STDMETHODCALLTYPE GetResourceAllocationInfo( 
            _In_  UINT visibleMask,
            _In_  UINT numResourceDescs,
            _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs) = 0;
#else
        virtual D3D12_RESOURCE_ALLOCATION_INFO *STDMETHODCALLTYPE GetResourceAllocationInfo( 
            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
            _In_  UINT visibleMask,
            _In_  UINT numResourceDescs,
            _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC *pResourceDescs) = 0;
#endif

#if defined(_MSC_VER) || !defined(_WIN32)
        virtual D3D12_RESOURCE_ALLOCATION_INFO STDMETHODCALLTYPE GetResourceAllocationInfo2( 
            UINT visibleMask,
            UINT numResourceDescs,
            _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC1 *pResourceDescs,
            _Out_writes_opt_(numResourceDescs)  D3D12_RESOURCE_ALLOCATION_INFO1 *pResourceAllocationInfo1) = 0;
#else
        virtual D3D12_RESOURCE_ALLOCATION_INFO *STDMETHODCALLTYPE GetResourceAllocationInfo2( 
            D3D12_RESOURCE_ALLOCATION_INFO * RetVal,
            UINT visibleMask,
            UINT numResourceDescs,
            _In_reads_(numResourceDescs)  const D3D12_RESOURCE_DESC1 *pResourceDescs,
            _Out_writes_opt_(numResourceDescs)  D3D12_RESOURCE_ALLOCATION_INFO1 *pResourceAllocationInfo1) = 0;
#endif
```

Notably, the function signatures are different when compiling with something other than MSVC. I'm going to assume GCC and Clang handle the calling convention differently. Attempting to compile D3D12MemoryAllocator with GCC or Clang using these headers currently fails while trying to build the `GetResourceAllocationInfoNative` functions as they assume the MSVC function definition.

The solution is simple, just #ifdef a variant for the GCC/Clang version of the function.

This is all that's needed for D3D12MemoryAllocator to build on GCC/Clang, at least with the https://github.com/microsoft/DirectX-Headers headers. These headers are needed as the mingw d3d12 headers are _very_ outdated and some of the D3D12_HEAP_FLAGS this library needs aren't defined. They also aren't new enough for my purposes as I'm using the enhanced barrier API and need CreateResource3 to be exposed.

This should just work transparently whether you're using the mingw headers, assuming they get updated, as the mingw headers define an overload for functions like `GetResourceAllocationInfo` that matches the MSVC signature so both calling styles can be used and it will just resolve to whichever overload is being selected by the #ifdef logic. For reference, the mingw headers look like this:

```cpp
#ifdef WIDL_EXPLICIT_AGGREGATE_RETURNS
    virtual D3D12_RESOURCE_ALLOCATION_INFO* STDMETHODCALLTYPE GetResourceAllocationInfo(
        D3D12_RESOURCE_ALLOCATION_INFO *__ret,
        UINT visible_mask,
        UINT reource_desc_count,
        const D3D12_RESOURCE_DESC *resource_descs) = 0;
    D3D12_RESOURCE_ALLOCATION_INFO STDMETHODCALLTYPE GetResourceAllocationInfo(
        UINT visible_mask,
        UINT reource_desc_count,
        const D3D12_RESOURCE_DESC *resource_descs)
    {
        D3D12_RESOURCE_ALLOCATION_INFO __ret;
        return *GetResourceAllocationInfo(&__ret, visible_mask, reource_desc_count, resource_descs);
    }
#else
    virtual D3D12_RESOURCE_ALLOCATION_INFO STDMETHODCALLTYPE GetResourceAllocationInfo(
        UINT visible_mask,
        UINT reource_desc_count,
        const D3D12_RESOURCE_DESC *resource_descs) = 0;
#endif
```