### PR TITLE
Eliminate warning in D3D12MA

### DIFF
--- a/include/D3D12MemAlloc.h
+++ b/include/D3D12MemAlloc.h
@@ -160,9 +160,9 @@ class D3D12MA_API IUnknownImpl : public IUnknown
 {
 public:
     virtual ~IUnknownImpl() = default;
-    virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
-    virtual ULONG STDMETHODCALLTYPE AddRef();
-    virtual ULONG STDMETHODCALLTYPE Release();
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override;
+    ULONG STDMETHODCALLTYPE AddRef() override;
+    ULONG STDMETHODCALLTYPE Release() override;
 protected:
     virtual void ReleaseThis() { delete this; }
 private:


### PR DESCRIPTION
> warning: 'QueryInterface' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]

Patch originally found in Qt:
https://github.com/qt/qtbase/blob/aec8398d71d351e956683a695af51317fe65097e/src/3rdparty/D3D12MemoryAllocator/patches/0001-Eliminate-warnings-in-D3D12MA.patch