### PR TITLE
Fix initialization order warning

### DIFF
--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -2795,7 +2795,7 @@ class AllocationObjectAllocator
     D3D12MA_CLASS_NO_COPY(AllocationObjectAllocator);
 public:
     AllocationObjectAllocator(const ALLOCATION_CALLBACKS& allocationCallbacks, bool useMutex)
-        : m_Allocator(allocationCallbacks, 1024), m_UseMutex(useMutex) {}
+		: m_UseMutex(useMutex), m_Allocator(allocationCallbacks, 1024) {}
 
     template<typename... Types>
     Allocation* Allocate(Types... args);


### PR DESCRIPTION
`bool m_UseMutex;` is declared first, thus it must be initialized first in the constructor or else a warning ensues.

This is important for projects that compile with warnings as errors enabled.