### PR TITLE
Fix small alignment support

### DIFF
--- a/src/D3D12MemAlloc.cpp
+++ b/src/D3D12MemAlloc.cpp
@@ -7793,7 +7793,9 @@ HRESULT AllocatorPimpl::GetResourceAllocationInfo(
 
 #if D3D12MA_USE_SMALL_RESOURCE_PLACEMENT_ALIGNMENT
     if (inOutResourceDesc.Alignment == 0 &&
-        inOutResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D &&
+        (inOutResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE1D || 
+            inOutResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D || 
+            inOutResourceDesc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D) &&
         (inOutResourceDesc.Flags & (D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL)) == 0
 #if D3D12MA_USE_SMALL_RESOURCE_PLACEMENT_ALIGNMENT == 1
         && CanUseSmallAlignment(inOutResourceDesc)


### PR DESCRIPTION
Earlier with `D3D12MA_USE_SMALL_RESOURCE_PLACEMENT_ALIGNMENT=2`, only Texture2Ds had been supported, but this change extends the support to both 1D and 3D textures too because the documentation of DX12 does not mention anything against that.